### PR TITLE
fix: handle optional tuple elements and rest tuples in GetKey

### DIFF
--- a/src/lib/GetKey.ts
+++ b/src/lib/GetKey.ts
@@ -1,18 +1,47 @@
 /**
+ * Convert a string to a number literal type.
+ * "0" -> 0, "1" -> 1, etc.
+ */
+type ToNumber<S extends string> = S extends `${infer N extends number}`
+  ? N
+  : never;
+
+/**
+ * Extract the fixed numeric indices from a tuple (excluding array prototype keys).
+ * [string, ...number[]] -> "0"
+ * [string, boolean, ...number[]] -> "0" | "1"
+ * string[] -> never
+ */
+type TupleKeys<T> = T extends readonly unknown[]
+  ? Exclude<keyof T, keyof unknown[]>
+  : never;
+
+/**
+ * Check if K is a fixed index in tuple T (not part of the rest portion).
+ */
+type IsFixedIndex<T extends readonly unknown[], K extends string> =
+  K extends TupleKeys<T> ? true : false;
+
+/**
  * Can't simply use T[K] because if T is a union type, then K may not be a key,
  * when really we want to just treat it as an optional key.
  */
-export type GetKey<
-  T,
-  K extends string | number,
-> = T extends readonly (infer V)[]
+export type GetKey<T, K extends string | number> = T extends readonly unknown[]
   ? number extends T["length"]
-    ? V | undefined // Dynamic Array
-    : T extends { [k in K & `${number}`]: infer V } // Tuple
-      ? V
+    ? // Dynamic array or rest tuple - use direct index access
+      ToNumber<K & string> extends keyof T
+      ? IsFixedIndex<T, K & string> extends true
+        ? T[ToNumber<K & string>] // Fixed position
+        : T[ToNumber<K & string>] | undefined // Rest position
+      : T[number] | undefined // Fallback
+    : // Fixed-length tuple
+      ToNumber<K & string> extends keyof T
+      ? undefined extends T[ToNumber<K & string>]
+        ? T[ToNumber<K & string>] | undefined // Optional element
+        : T[ToNumber<K & string>] // Required element
       : never
-  : T extends { [k in K]: infer V } // Object
+  : T extends { [k in K]: infer V }
     ? V
-    : T extends { [k in K]?: infer V } // Object with optional key
+    : T extends { [k in K]?: infer V }
       ? V | undefined
       : undefined;


### PR DESCRIPTION
## Summary

- Fix optional tuple elements returning `never` instead of `T | undefined`
- Fix tuples with rest elements (e.g., `[string, ...number[]]`) being treated incorrectly
  - Index 0 in `[string, ...number[]]` now correctly returns `string` (fixed position)
  - Index 1+ now correctly returns `number | undefined` (rest position, may not exist)
- Add comprehensive edge case tests covering tuples, arrays, unions, and more (65+ new tests)

## Implementation

The key insight was that property inference (`T extends { [k in K]: infer V }`) fails for rest tuple indices because they aren't guaranteed to exist. The fix uses:

1. **`ToNumber<S>`** - Converts string keys to number literals (`"1"` → `1`)
2. **`TupleKeys<T>`** - Extracts fixed numeric indices by excluding array prototype keys
3. **Direct index access** - `T[ToNumber<K>]` works where property inference fails

## Test plan

- [x] All 106 tests pass
- [x] Lint passes
- [x] New edge case tests for:
  - Optional tuple elements
  - Rest tuples with fixed prefixes
  - Plain dynamic arrays
  - Unions, intersections, branded types
  - And more...

🤖 Generated with [Claude Code](https://claude.com/claude-code)