### PR TITLE
feat: support Path traversal for static class members

### DIFF
--- a/src/lib/IsLeafType.ts
+++ b/src/lib/IsLeafType.ts
@@ -2,7 +2,7 @@ import { BuiltIn } from "./BuiltIn";
 
 /**
  * Types that should never be recursed into for path generation.
- * Includes primitives, built-in objects, functions, constructors, promises,
+ * Includes primitives, built-in objects, functions, promises,
  * and collection types (Map, Set, WeakMap, WeakSet).
  *
  * Aligned with type-fest's NonRecursiveType for compatibility.
@@ -10,7 +10,6 @@ import { BuiltIn } from "./BuiltIn";
 type NonRecursiveType =
   | BuiltIn
   | ((...args: unknown[]) => unknown) // Functions
-  | (new (...args: unknown[]) => unknown) // Class constructors
   | Promise<unknown>
   | ReadonlyMap<unknown, unknown>
   | Map<unknown, unknown>

--- a/src/lib/get.type.test.ts
+++ b/src/lib/get.type.test.ts
@@ -609,6 +609,24 @@ describe("Edge cases", () => {
       assertExtends<"name", Paths>(true);
       assertExtends<"getValue", Paths>(true);
     });
+
+    it("handles static methods on classes", () => {
+      class MyClass {
+        static staticMethod(): string {
+          return "";
+        }
+        static staticProperty = 42;
+        instanceMethod(): number {
+          return 0;
+        }
+      }
+      // typeof MyClass gives us the constructor/static side
+      type StaticPaths = Path<typeof MyClass, Depth<1>>;
+      assertExtends<"staticMethod", StaticPaths>(true);
+      assertExtends<"staticProperty", StaticPaths>(true);
+      // instance methods should NOT appear on the static side
+      assertExtends<"instanceMethod", StaticPaths>(false);
+    });
   });
 
   describe("branded/nominal types", () => {


### PR DESCRIPTION
## Summary

- Remove class constructor pattern from `NonRecursiveType` in `IsLeafType.ts`
- This allows `Path<typeof MyClass>` to traverse static properties and methods
- Add test coverage for static class member paths

## Problem

Previously, `typeof MyClass` was treated as a leaf type because it matched the constructor signature pattern `(new (...args: unknown[]) => unknown)`. This prevented `Path` from generating paths for static properties and methods.

```typescript
class MyClass {
  static staticMethod(): string { return ""; }
  static staticProperty = 42;
}

// Before: Path<typeof MyClass> = never
// After: Path<typeof MyClass> = "staticMethod" | "staticProperty" | "prototype"
```

## Test plan

- [x] Added test case for static methods and properties on classes
- [x] All existing tests pass
- [x] Type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)